### PR TITLE
Fix carriage return bug in barcode setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ app.*.map.json
 /android/app/release
 assets/barcodes.txt
 android/app/google-services.json
+assets/barcodes_ce.txt
+assets/barcodes_se.txt

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
 
 import 'firebase_options.dart';
 import 'scanner_view/scanner_view.dart';
@@ -9,7 +9,11 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  // Database.setUpBarcodes('assets/barcodes.txt');
+  
+  // Database.setUpBarcodes('assets/barcodes_ce.txt', 'ce', 'FreshersParty_2024');
+  // Database.setUpBarcodes('assets/barcodes_se.txt', 'se', 'FreshersParty_2024');
+  // Database.setUpBarcodes('assets/barcodes.txt', 'se', 'barcodes');
+  
   runApp(const MyApp());
 }
 

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -37,7 +37,7 @@ class Database {
         .snapshots();
   }
 
-  static setUpBarcodes(String path) async {
+  static setUpBarcodes(String path, String type, collection) async {
     if (!kDebugMode) return;
     
     final firestore = FirebaseFirestore.instance;
@@ -45,13 +45,15 @@ class Database {
 
     final fileString = await rootBundle.loadString(path);
     fileString.split("\n").forEach((line) {
-      final id = line;
-      const scanned = false;
-      final timestamp = DateTime.fromMillisecondsSinceEpoch(1641031200000);   // 2022-01-01 10:00:00.000Z
+      final barcode = line.trim();  // Remove the carriage return
 
-      final docRef = firestore.collection('FreshersParty_2024').doc(id);
-      batch.set(docRef, { 'scanned': scanned, 'timestamp': timestamp });
-      debugPrint(line);
+      final docRef = firestore.collection(collection).doc(barcode);
+      batch.set(docRef, {
+        'scanned': false,
+        'timestamp': DateTime.fromMillisecondsSinceEpoch(0),
+        'type': type,
+      });
+      debugPrint(barcode);
     });
 
     try {


### PR DESCRIPTION
This pull request fixes a bug in the barcode setup where a carriage return was not being properly removed from the barcode string. This caused issues when setting up barcodes for scanning. The bug has been fixed by trimming the barcode string to remove any leading or trailing whitespace.