### PR TITLE
Refactor database query and add barcode reset feature

### DIFF
--- a/lib/components/barcode_row.dart
+++ b/lib/components/barcode_row.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:party_scan/services/database.dart';
 
 class BarcodeRow extends StatelessWidget {
   final DocumentSnapshot document;
@@ -23,6 +24,32 @@ class BarcodeRow extends StatelessWidget {
           color: Colors.white,
         ),
       ),
+      onLongPress: () {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return AlertDialog(
+              title: const Text("Confirm Reset"),
+              content: const Text("Are you sure you want to reset this barcode?"),
+              actions: [
+                TextButton(
+                  child: const Text("Cancel"),
+                  onPressed: () {
+                    Navigator.of(context).pop(false);
+                  },
+                ),
+                TextButton(
+                  child: const Text("Confirm"),
+                  onPressed: () {
+                    Database.resetBarcode(document.id);
+                    Navigator.of(context).pop(true);
+                  },
+                ),
+              ],
+            );
+          },
+        );
+      },
     );
   }
 }

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -33,7 +33,6 @@ class Database {
     return FirebaseFirestore.instance
         .collection(collection)
         .where('scanned', isEqualTo: false)
-        .orderBy("timestamp", descending: true)
         .snapshots();
   }
 

--- a/lib/services/database.dart
+++ b/lib/services/database.dart
@@ -36,6 +36,14 @@ class Database {
         .snapshots();
   }
 
+  static Future<void> resetBarcode(String barcode) async {
+    final collection = await SharedPrefs.getCollectionName() as String;
+    await FirebaseFirestore.instance.collection(collection).doc(barcode).update({
+      'scanned': false,
+      'timestamp': DateTime.fromMillisecondsSinceEpoch(0),
+    });
+  }
+
   static setUpBarcodes(String path, String type, collection) async {
     if (!kDebugMode) return;
     


### PR DESCRIPTION
This pull request includes a refactoring of the database query to remove an unnecessary orderBy clause. Additionally, it adds a new feature to reset a barcode. The reset functionality is triggered by a long press on a barcode, which opens a confirmation dialog. Upon confirmation, the barcode is reset by updating the corresponding document in the database.